### PR TITLE
feat: adds a 'withConnectionFromPool' function that calls 'closeConnection' rather than 'releaseConnection' after performing the supplied action.

### DIFF
--- a/src/Database/Dpi.hs
+++ b/src/Database/Dpi.hs
@@ -516,6 +516,12 @@ withPool p conf hpcp
 withPoolConnection :: PtrPool -> (PtrConn -> IO a) -> IO a
 withPoolConnection p = bracket (acquiredConnection p) releaseConnection
 
+-- | Acquires a connection from the pool, calling 'closeConnection' after the action.
+--   Compare with 'withPoolConnection', which calls 'releaseConnection' after the action.
+{-# INLINE withConnectionFromPool #-}
+withConnectionFromPool :: PtrPool -> (PtrConn -> IO a) -> IO a
+withConnectionFromPool p = bracket (acquiredConnection p) (closeConnection ModeConnCloseDefault)
+
 -- | Returns the number of sessions in the pool that are busy.
 {-# INLINE getPoolBusyCount #-}
 getPoolBusyCount :: PtrPool -> IO Int


### PR DESCRIPTION
Empirically, we've discovered that using `withPoolConnection` can sometimes result in connections that are erroneously perceived as still being in use. `withPoolConnection` calls `releaseConnection` after the action.

This PR adds a function called `withConnectionFromPool` that calls `closeConnection` after the action instead of `releaseConnection`. Despite the name, this will not necessarily terminate the connection / session. If the connection came from a connection pool, it will typically be returned to the pool, and the time it was last used will be set.

See https://github.com/liminalisht/odpic-raw/blob/master/include/dpiConn.c#L248 for more details.